### PR TITLE
Performance improvements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ module.exports = postcss.plugin('css-declaration-sorter', function (options) {
       }
 
       if (~comment.raws.before.indexOf('\n')) {
-        newline.push({
+        newline.unshift({
           'comment': comment,
           'pairedNode': comment.next()
         });
@@ -58,9 +58,6 @@ module.exports = postcss.plugin('css-declaration-sorter', function (options) {
 
       comment.remove();
     });
-
-    // Reverse order because newline comments are inserted before the next node
-    newline.reverse();
 
     return {
       'newline': newline,

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ function sortCssDecls (cssDecls, sortOrder) {
 function processCss (css, sortOrder) {
   const newline = [];
   const inline = [];
-  const cached = [];
+  const rulesCache = [];
 
   css.walk(function (node) {
     const nodes = node.nodes;
@@ -67,12 +67,12 @@ function processCss (css, sortOrder) {
     // comment nodes before we start sorting.
     const isRule = type === 'rule' || type === 'atrule';
     if (isRule && nodes && nodes.length > 1) {
-      cached.push(nodes);
+      rulesCache.push(nodes);
     }
   });
 
   // Perform a sort once all comment nodes are removed
-  cached.forEach(function (nodes) {
+  rulesCache.forEach(function (nodes) {
     sortCssDecls(nodes, sortOrder);
   });
 


### PR DESCRIPTION
* Call `unshift` rather than `push` followed by `reverse`. - by the way, this doesn't seem to be tested properly, if I would simply remove the `reverse` from the array all tests pass; so is this necessary?
* Perform a single walk of the AST, rather than two.

I've also extracted the bulk of the methods out of the plugin function, I think it's a little more readable this way. 😄 