### PR TITLE
fix: don't move Sass variables

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,10 @@ const path = require('path');
 
 const postcss = require('postcss');
 const timsort = require('timsort').sort;
+const Stringifier = require('postcss/lib/stringifier');
+
+// Stringify variables just like declarations.
+Stringifier.prototype.variable = Stringifier.prototype.decl;
 
 module.exports = postcss.plugin('css-declaration-sorter', function (options) {
   return function (css) {
@@ -41,6 +45,13 @@ function processCss (css, sortOrder) {
   css.walk(function (node) {
     const nodes = node.nodes;
     const type = node.type;
+
+    if (type === 'decl') {
+      if (node.prop[0] === '$') {
+        node.type = 'variable';
+      }
+      return;
+    }
 
     if (type === 'comment') {
       // Don't do anything to root comments or the last newline comment
@@ -125,7 +136,6 @@ function comparator (a, b) {
 }
 
 function compareDifferentType (a, b) {
-  if (b.type === 'atrule') { return  0; }
-
+  if (b.type === 'atrule' || b.type === 'variable') return 0;
   return (a.type === 'decl') ? -1 : (b.type === 'decl') ? 1 : 0;
 }

--- a/tests/test.js
+++ b/tests/test.js
@@ -67,6 +67,21 @@ const sortOrderTests = [
     fixture: 'a{border: 0;@import sii;flex:0;}',
     expected: 'a{border: 0;@import sii;flex:0;}',
   },
+  {
+    message: 'Keep CSS variables at the same position.',
+    fixture: 'a{border: 0;--bg-color: blue;}',
+    expected: 'a{border: 0;--bg-color: blue;}',
+  },
+  {
+    message: 'Keep Less variables at the same position.',
+    fixture: 'a{border: 0;@bg-color: blue;}',
+    expected: 'a{border: 0;@bg-color: blue;}',
+  },
+  {
+    message: 'Keep SCSS variables at the same position.',
+    fixture: 'a{border: 0;$bg-color: blue;}',
+    expected: 'a{border: 0;$bg-color: blue;}',
+  },
 ];
 
 const commentOrderTests = [


### PR DESCRIPTION
When using [`postcss-scss`](https://github.com/postcss/postcss-scss) syntax, variables are parsed with the `decl` type, which causes variables to be reordered (which is undesirable).