### PR TITLE
Replace built-in order JSON loading with native importing

### DIFF
--- a/orders/alphabetical.mjs
+++ b/orders/alphabetical.mjs
@@ -1,4 +1,4 @@
-[
+export const properties = [
   "all",
   "-webkit-line-clamp",
   "align-content",

--- a/orders/concentric-css.mjs
+++ b/orders/concentric-css.mjs
@@ -1,4 +1,4 @@
-[
+export const properties = [
   "all",
   "display",
   "position",

--- a/orders/smacss.mjs
+++ b/orders/smacss.mjs
@@ -1,4 +1,4 @@
-[
+export const properties = [
   "all",
   "box-sizing",
   "contain",

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -1,10 +1,5 @@
-import { promises as fs } from 'fs';
 import shorthandData from './shorthand-data.mjs';
-import path from 'path';
-import { fileURLToPath } from 'url';
 import { sort as timsort } from 'timsort';
-
-const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
 
 const builtInOrders = [
   'alphabetical',
@@ -32,11 +27,10 @@ const pluginEntrypoint = ({ order = 'alphabetical', keepOverrides = false } = {}
         ].join('\n'))
       );
 
-    // Load in the array containing the order from a JSON file
-    return fs.readFile(path.resolve(currentDirectory, '..', 'orders', order) + '.json')
-      .then(data => processCss({
+    return import(`../orders/${order}.mjs`)
+      .then(({ properties }) => processCss({
         css,
-        comparator: withKeepOverrides(orderComparator(JSON.parse(data))),
+        comparator: withKeepOverrides(orderComparator(properties)),
       }));
   },
 });

--- a/src/property-scraper.mjs
+++ b/src/property-scraper.mjs
@@ -22,6 +22,6 @@ const cssProperties = Object.entries({ ...css.properties, ...css['at-rules']['fo
   .sort();
 
 fs.writeFile(
-  'orders/alphabetical.json',
-  JSON.stringify(cssProperties, null, 2),
+  'orders/alphabetical.mjs',
+  `export const properties = ${JSON.stringify(cssProperties, null, 2)}`,
 );


### PR DESCRIPTION
Simplifies and speeds up loading, also allowing code to run in other
environments like the browser.

Closes #172

If you have time to check the code I would appreciate a review @ludofischer.