### PR TITLE
Use caching that comes with actions/setup-node

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -15,13 +15,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Use dependencies cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: npm-${{ hashFiles('package-lock.json') }}
-          restore-keys: npm-
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci --ignore-scripts


### PR DESCRIPTION
## Changes:

- Use caching that comes with `actions/setup-node`
- Remove "Use dependencies cache" step

## Context:

`actions/setup` node now comes with a easy way to cache your dependencies.
Read the [changelog for `actions/setup-node@v2.2.0`](https://github.com/actions/setup-node/releases/tag/v2.2.0).

Caching will only work when there's a lock file in the _root_ of the repository.
The action supports caching for Yarn, npm, and pnpm.

The benefit is that you're relying on fewer actions, and that the new method of caching is way easier to setup and use than the old method.