### PR TITLE
Add defensive paired comment node parent check

### DIFF
--- a/src/main.mjs
+++ b/src/main.mjs
@@ -96,7 +96,7 @@ function processCss ({ css, comparator }) {
   comments.forEach(node => {
     const pairedNode = node.pairedNode;
     node.comment.remove();
-    pairedNode.parent['insert' + node.insertPosition](pairedNode, node.comment);
+    pairedNode.parent && pairedNode.parent['insert' + node.insertPosition](pairedNode, node.comment);
   });
 }
 


### PR DESCRIPTION
SCSS loaders parse special `/*!` comments causing a comment to miss a
parent node.

Closes #215
