### PR TITLE
Allow to pass an array of declaration names to order option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-declaration-sorter",
-  "version": "6.3.1",
+  "version": "6.4.1",
   "description": "Sorts CSS declarations fast and automatically in a certain order.",
   "type": "module",
   "main": "./dist/main.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-declaration-sorter",
-  "version": "6.4.1",
+  "version": "6.4.0",
   "description": "Sorts CSS declarations fast and automatically in a certain order.",
   "type": "module",
   "main": "./dist/main.cjs",

--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ Type: `string` or `function`
 Default: `alphabetical`  
 Options: `alphabetical`, `smacss`, `concentric-css`
 
-Provide the name of one of the built-in sort orders or a comparison function that is passed to ([`Array.sort`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)). This function receives two declaration names and is expected to return `-1`, `0` or `1` depending on the wanted order.
+Provide the name of one of the built-in sort orders, an array of declaration names in your desired order, a comparison function that is passed to ([`Array.sort`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)). This function receives two declaration names and is expected to return `-1`, `0` or `1` depending on the wanted order.
 
 #### keepOverrides
 Type: `Boolean`  

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -18,6 +18,10 @@ export const cssDeclarationSorter = ({ order = 'alphabetical', keepOverrides = f
       return processCss({ css, comparator: withKeepOverrides(order) });
     }
 
+    if (Array.isArray(order)) {
+      return processCss({ css, comparator: withKeepOverrides(((a, b) => order.indexOf(a) - order.indexOf(b))) });
+    }
+
     if (!builtInOrders.includes(order))
       return Promise.reject(
         Error([

--- a/src/main.test.mjs
+++ b/src/main.test.mjs
@@ -46,6 +46,18 @@ const sortOrderTests = [
     options: { order: () => 1 },
   },
   {
+    message: 'Sort according to custom order, changed.',
+    fixture: 'a{border: 0;z-index: 0;}',
+    expected: 'a{z-index: 0;border: 0;}',
+    options: { order: ['z-index', 'border'] },
+  },
+  {
+    message: 'Sort according to custom order, retained.',
+    fixture: 'a{border: 0;z-index: 0;}',
+    expected: 'a{border: 0;z-index: 0;}',
+    options: { order: ['border', 'z-index'] },
+  },
+  {
     message: 'Sort according to SMACSS.',
     fixture: 'a{border: 0;flex: 0;}',
     expected: 'a{flex: 0;border: 0;}',


### PR DESCRIPTION
This is needed to allow configuring custom declaration names order for prettier-plugin-css-order provided as an array of names. There is no option to pass comparer function as it results in an exeption from sync-threads: "DataCloneError: function could not be cloned." 

PS. After this PR is merged and published I'll create a PR to prettier-plugin-css-order repo.