### PR TITLE
fix: Add bubble-sort.mjs to files array.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "./dist/main.cjs",
   "exports": {
+    "types": "./src/main.d.ts",
     "import": "./src/main.mjs",
     "require": "./dist/main.cjs"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-declaration-sorter",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Sorts CSS declarations fast and automatically in a certain order.",
   "type": "module",
   "main": "./dist/main.cjs",
@@ -13,6 +13,7 @@
     "src/main.mjs",
     "src/main.d.ts",
     "src/shorthand-data.mjs",
+    "src/bubble-sort.mjs",
     "orders",
     "dist"
   ],


### PR DESCRIPTION
Closes: https://github.com/Siilwyn/css-declaration-sorter/issues/327

This should likely be back ported to a new `6.4.1` release since the v6 line appears to have this same issue!