### PR TITLE
Retain unknown property position to prevent overrides

### DIFF
--- a/src/core/main.mjs
+++ b/src/core/main.mjs
@@ -129,7 +129,13 @@ function withOverridesComparator (shorthandData) {
 
 function orderComparator (order) {
   return function (a, b) {
-    return order.indexOf(a) - order.indexOf(b);
+    const bIndex = order.indexOf(b);
+
+    if (bIndex === -1) {
+      return 0;
+    }
+
+    return order.indexOf(a) - bIndex;
   };
 }
 

--- a/src/core/main.test.mjs
+++ b/src/core/main.test.mjs
@@ -63,9 +63,24 @@ const sortOrderTests = [
     expected: 'a{border: 0;@import sii;flex:0;}',
   },
   {
-    message: 'Retain unkown properties',
-    fixture: 'a{unkown-b: 0; unkown-a: 0;}',
-    expected: 'a{unkown-b: 0; unkown-a: 0;}',
+    message: 'Retain unknown properties, left to right.',
+    fixture: 'a{unknown-a: 0;unknown-b: 0;}',
+    expected: 'a{unknown-a: 0;unknown-b: 0;}',
+  },
+  {
+    message: 'Retain unknown properties, right to left.',
+    fixture: 'a{unknown-b: 0;unknown-a: 0;}',
+    expected: 'a{unknown-b: 0;unknown-a: 0;}',
+  },
+  {
+    message: 'Retain unknown next to known properties, left to right.',
+    fixture: 'a{animation: 0;animation-timeline: none;}',
+    expected: 'a{animation: 0;animation-timeline: none;}',
+  },
+  {
+    message: 'Retain unknown next to known properties, right to left.',
+    fixture: 'a{animation-timeline: none;animation: 0;}',
+    expected: 'a{animation-timeline: none;animation: 0;}',
   },
   {
     message: 'Sort shorthand, resulting in impactful ordering.',


### PR DESCRIPTION
Sorting unknown properties like new experimental CSS overrides can break
styling. To prevent this keep declarations around these unknowns in the
same place.

Closes #338
