### PR TITLE
add text-wrap-mode, text-wrap-style, -webkit-font-smoothing

### DIFF
--- a/src/orders/alphabetical.mjs
+++ b/src/orders/alphabetical.mjs
@@ -377,6 +377,8 @@ export const properties = [
   "text-underline-offset",
   "text-underline-position",
   "text-wrap",
+  "text-wrap-mode",
+  "text-wrap-style",
   "top",
   "touch-action",
   "transform",

--- a/src/orders/alphabetical.mjs
+++ b/src/orders/alphabetical.mjs
@@ -1,5 +1,6 @@
 export const properties = [
   "all",
+  "-webkit-font-smoothing",
   "-webkit-line-clamp",
   "-webkit-text-fill-color",
   "-webkit-text-stroke",

--- a/src/orders/concentric-css.mjs
+++ b/src/orders/concentric-css.mjs
@@ -258,6 +258,7 @@ export const properties = [
   "height",
   "min-height",
   "max-height",
+  "-webkit-font-smoothing",
   "-webkit-line-clamp",
   "-webkit-text-fill-color",
   "-webkit-text-stroke",

--- a/src/orders/concentric-css.mjs
+++ b/src/orders/concentric-css.mjs
@@ -401,6 +401,8 @@ export const properties = [
   "text-shadow",
   "text-transform",
   "text-wrap",
+  "text-wrap-mode",
+  "text-wrap-style",
   "white-space",
   "white-space-collapse",
   "word-break",

--- a/src/orders/smacss.mjs
+++ b/src/orders/smacss.mjs
@@ -302,6 +302,8 @@ export const properties = [
   "text-shadow",
   "text-transform",
   "text-wrap",
+  "text-wrap-mode",
+  "text-wrap-style",
   "vertical-align",
   "baseline-source",
   "white-space",

--- a/src/orders/smacss.mjs
+++ b/src/orders/smacss.mjs
@@ -69,6 +69,7 @@ export const properties = [
   "height",
   "min-height",
   "max-height",
+  "-webkit-font-smoothing",
   "-webkit-line-clamp",
   "-webkit-text-fill-color",
   "-webkit-text-stroke",


### PR DESCRIPTION
thanks for the amazing plugin!

I've added `text-wrap-mode`, `text-wrap-style`, and `-webkit-font-smoothing` in the properties list.

https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap-mode
https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap-style
https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth